### PR TITLE
Relaxing version bounds for supporting ghc 9.10

### DIFF
--- a/fernet.cabal
+++ b/fernet.cabal
@@ -29,13 +29,13 @@ library
                      , Network.Fernet.Crypto
                      , Network.Fernet.Key
                      , Network.Fernet.Token
-  build-depends:       base >=4.9 && <4.18
+  build-depends:       base                 >= 4.9    && < 4.21
                      , binary               >= 0.8.3.0 && < 0.10
                      , byteable             >= 0.1.1  && < 0.2
-                     , bytestring           >= 0.10.8 && < 0.12
+                     , bytestring           >= 0.10.8 && < 0.13
                      , cryptonite           >= 0.21   && < 0.31
-                     , memory               >= 0.14.1 && < 0.18
-                     , time                 >= 1.6.0  && < 1.10
+                     , memory               >= 0.14.1 && < 0.20
+                     , time                 >= 1.6.0  && < 1.15
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
@@ -53,10 +53,10 @@ executable fernet
   build-depends:       base
                      , fernet
                      , bytestring
-                     , optparse-applicative >= 0.12 && < 0.15
+                     , optparse-applicative >= 0.12 && < 0.19
                      , memory
                      , time
-                     , unix                 >= 2.7.2.1 && < 2.8
+                     , unix                 >= 2.7.2.1 && < 2.9
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
 
@@ -68,7 +68,7 @@ test-suite fernet-test
   other-modules:       Network.Fernet.Tests
   build-depends:       HUnit
                      , QuickCheck
-                     , aeson                >= 1.0.2  && < 1.1
+                     , aeson                >= 1.0.2  && < 2.3
                      , base
                      , bytestring
                      , fernet

--- a/test/Network/Fernet/Tests.hs
+++ b/test/Network/Fernet/Tests.hs
@@ -9,7 +9,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as S8
 import Data.Maybe (fromJust, fromMaybe)
 import Data.Either (isLeft)
-import Data.Aeson
+import Data.Aeson hiding (Key)
 import Control.Applicative
 import Data.Time.Clock (NominalDiffTime)
 import Data.Time.LocalTime (zonedTimeToUTC)
@@ -48,7 +48,7 @@ instance FromJSON Spec where
         <*> liftA S8.pack (v .:? "src" .!= "")
         <*> liftA BS.pack (v .:? "iv" .!= [])
 
-parseTime :: Monad m => String -> m POSIXTime
+parseTime :: MonadFail m => String -> m POSIXTime
 parseTime = fmap (utcTimeToPOSIXSeconds . zonedTimeToUTC) . parseTimeM False defaultTimeLocale fmt
   where fmt = "%Y-%m-%dT%H:%M:%S%z"
 


### PR DESCRIPTION
I conformed that `cabal test all` succeeded with GHC 9.8.2 and 9.10.1.